### PR TITLE
✨ feat(finances): add financial history with month navigation

### DIFF
--- a/app/(tabs)/__tests__/finances.test.tsx
+++ b/app/(tabs)/__tests__/finances.test.tsx
@@ -101,13 +101,52 @@ jest.mock('@/components/finance/CategoryBudgetModal', () => {
 
 jest.mock('@/components/finance/ExpenseItem', () => {
   const React = jest.requireActual('react') as typeof import('react');
-  const { TouchableOpacity } = jest.requireActual('react-native') as typeof import('react-native');
+  const { TouchableOpacity, Text } = jest.requireActual(
+    'react-native'
+  ) as typeof import('react-native');
   return {
-    ExpenseItem: ({ expense, onDelete }: { expense: { id: string }; onDelete?: () => void }) =>
-      React.createElement(TouchableOpacity, {
-        testID: `mock-expense-delete-${expense.id}`,
-        onPress: onDelete,
-      }),
+    ExpenseItem: ({
+      expense,
+      onDelete,
+    }: {
+      expense: { id: string; amount: number };
+      onDelete?: () => void;
+    }) =>
+      React.createElement(
+        TouchableOpacity,
+        { testID: `mock-expense-delete-${expense.id}`, onPress: onDelete },
+        React.createElement(Text, null, `$${expense.amount.toFixed(2)}`)
+      ),
+  };
+});
+
+jest.mock('@/components/finance/MonthPicker', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  const { View, TouchableOpacity, Text } = jest.requireActual(
+    'react-native'
+  ) as typeof import('react-native');
+  return {
+    MonthPicker: ({
+      month,
+      onPrev,
+      onNext,
+      disableNext,
+    }: {
+      month: string;
+      onPrev: () => void;
+      onNext: () => void;
+      disableNext: boolean;
+    }) =>
+      React.createElement(
+        View,
+        { testID: 'month-picker' },
+        React.createElement(Text, null, month),
+        React.createElement(TouchableOpacity, { testID: 'month-picker-prev', onPress: onPrev }),
+        React.createElement(View, {
+          testID: 'month-picker-next',
+          disabled: disableNext,
+        })
+      ),
   };
 });
 
@@ -468,5 +507,61 @@ describe('FinancesScreen additional branches', () => {
     const { getByText } = render(<FinancesScreen />);
     expect(getByText('Track a new transaction')).toBeTruthy();
     useSettingsStore.setState({ themePreference: 'light' });
+  });
+});
+
+describe('history section', () => {
+  const MAY = new Date('2025-05-10').getTime();
+  const JUNE = new Date('2025-06-20').getTime();
+
+  beforeEach(() => {
+    useFinanceStore.setState((s) => ({
+      ...s,
+      categories: [{ id: 'cat-food', name: 'Food', color: '#f97316' }],
+      expenses: [
+        { id: 'e-may', categoryId: 'cat-food', amount: 40, date: MAY },
+        { id: 'e-june', categoryId: 'cat-food', amount: 55, date: JUNE },
+      ],
+      budgets: [],
+    }));
+  });
+
+  it('renders the history section heading', () => {
+    const { getByText } = render(<FinancesScreen />);
+    expect(getByText('History')).toBeTruthy();
+  });
+
+  it('shows a MonthPicker defaulting to the most recent past month', () => {
+    const { getByTestId } = render(<FinancesScreen />);
+    expect(getByTestId('month-picker')).toBeTruthy();
+  });
+
+  it('shows expenses for the selected history month', () => {
+    const { getByText } = render(<FinancesScreen />);
+    // Default selected month is the newest past month (2025-06)
+    expect(getByText('$55.00')).toBeTruthy();
+  });
+
+  it('navigates to the previous month when prev is pressed', () => {
+    const { getByTestId, getByText } = render(<FinancesScreen />);
+    fireEvent.press(getByTestId('month-picker-prev'));
+    expect(getByText('$40.00')).toBeTruthy();
+  });
+
+  it('disables the next button when the selected month is the most recent month with expenses', () => {
+    const { getByTestId } = render(<FinancesScreen />);
+    const nextBtn = getByTestId('month-picker-next');
+    expect(nextBtn.props.disabled).toBe(true);
+  });
+
+  it('shows "No expenses this month" when the selected month has no expenses', () => {
+    useFinanceStore.setState((s) => ({
+      ...s,
+      expenses: [{ id: 'e-may', categoryId: 'cat-food', amount: 40, date: MAY }],
+    }));
+    const { getByText, getByTestId } = render(<FinancesScreen />);
+    // Default is 2025-05 (only month); press prev to go to 2025-04
+    fireEvent.press(getByTestId('month-picker-prev'));
+    expect(getByText('No expenses this month')).toBeTruthy();
   });
 });

--- a/app/(tabs)/finances.tsx
+++ b/app/(tabs)/finances.tsx
@@ -7,6 +7,7 @@ import { BudgetProgressBar } from '@/components/finance/BudgetProgressBar';
 import { CategoryBudgetModal } from '@/components/finance/CategoryBudgetModal';
 import { ExpenseForm } from '@/components/finance/ExpenseForm';
 import { ExpenseItem } from '@/components/finance/ExpenseItem';
+import { MonthPicker } from '@/components/finance/MonthPicker';
 import { Modal } from '@/components/ui/Modal';
 import { PaywallModal } from '@/components/ui/PaywallModal';
 import { useAppTheme } from '@/hooks/useAppTheme';
@@ -15,6 +16,7 @@ import { useEntitlementStore } from '@/stores/entitlementStore';
 import { useFinanceStore } from '@/stores/financeStore';
 import { currentMonth, todayString } from '@/utils/date';
 import { exportFinancesAsCsv, exportFinancesAsPdf } from '@/utils/financeExport';
+import { availableMonths, nextMonth, prevMonth } from '@/utils/historyUtils';
 
 export default function FinancesScreen() {
   const theme = useAppTheme();
@@ -39,6 +41,48 @@ export default function FinancesScreen() {
   );
 
   const month = currentMonth();
+
+  const allMonths = useMemo(() => availableMonths(expenses), [expenses]);
+  const historyMonths = useMemo(() => allMonths.filter((m) => m < month), [allMonths, month]);
+
+  const [historyMonth, setHistoryMonth] = useState<string | null>(
+    () => historyMonths[0] ?? null
+  );
+
+  useEffect(() => {
+    setHistoryMonth((prev) => {
+      if (!prev || !historyMonths.includes(prev)) return historyMonths[0] ?? null;
+      return prev;
+    });
+  }, [historyMonths]);
+
+  const historyExpenses = useMemo(
+    () =>
+      historyMonth
+        ? expenses
+            .filter((e) => new Date(e.date).toISOString().slice(0, 7) === historyMonth)
+            .sort((a, b) => b.date - a.date)
+        : [],
+    [expenses, historyMonth]
+  );
+
+  const historySpentByCategory = (categoryId: string) =>
+    historyExpenses.filter((e) => e.categoryId === categoryId).reduce((sum, e) => sum + e.amount, 0);
+
+  const historyGetBudgetLimit = (categoryId: string) =>
+    budgets.find((b) => b.categoryId === categoryId && b.month === historyMonth)?.monthlyLimit ?? 0;
+
+  const handleHistoryPrev = () => {
+    if (historyMonth) setHistoryMonth(prevMonth(historyMonth));
+  };
+
+  const handleHistoryNext = () => {
+    if (!historyMonth || historyMonth === historyMonths[0]) return;
+    setHistoryMonth(nextMonth(historyMonth));
+  };
+
+  const isHistoryNextDisabled = !historyMonth || historyMonth === historyMonths[0];
+
   const today = todayString();
   const year = today.slice(0, 4);
 
@@ -298,7 +342,7 @@ export default function FinancesScreen() {
           </Text>
           {monthExpenses.length === 0 ? (
             <Text className="text-sm py-4 text-center" style={{ color: theme.textSubtle }}>
-              No expenses this month
+              No expenses recorded yet
             </Text>
           ) : (
             monthExpenses.map((expense) => {
@@ -314,6 +358,56 @@ export default function FinancesScreen() {
             })
           )}
         </Animated.View>
+
+        {historyMonths.length > 0 && (
+          <Animated.View
+            entering={FadeInUp.delay(240).duration(260)}
+            layout={Layout.springify()}
+            className="px-4 mt-6 mb-8">
+            <Text className="text-base font-semibold mb-2" style={{ color: theme.textMuted }}>
+              History
+            </Text>
+            <View
+              className="rounded-2xl overflow-hidden"
+              style={{ borderColor: theme.border, borderWidth: 1, backgroundColor: theme.surface }}>
+              <MonthPicker
+                month={historyMonth!}
+                onPrev={handleHistoryPrev}
+                onNext={handleHistoryNext}
+                disableNext={isHistoryNextDisabled}
+              />
+              <View className="h-px" style={{ backgroundColor: theme.border }} />
+              <View className="px-3 py-3">
+                {categories.map((cat) => (
+                  <BudgetProgressBar
+                    key={cat.id}
+                    category={cat}
+                    spent={historySpentByCategory(cat.id)}
+                    limit={historyGetBudgetLimit(cat.id)}
+                  />
+                ))}
+                <View className="h-px my-2" style={{ backgroundColor: theme.border }} />
+                {historyExpenses.length === 0 ? (
+                  <Text className="text-sm py-2 text-center" style={{ color: theme.textSubtle }}>
+                    No expenses this month
+                  </Text>
+                ) : (
+                  historyExpenses.map((expense) => {
+                    const cat = categories.find((c) => c.id === expense.categoryId);
+                    return (
+                      <ExpenseItem
+                        key={expense.id}
+                        expense={expense}
+                        category={cat}
+                        onDelete={() => deleteExpense(expense.id)}
+                      />
+                    );
+                  })
+                )}
+              </View>
+            </View>
+          </Animated.View>
+        )}
       </ScrollView>
 
       <CategoryBudgetModal visible={showSettings} onClose={() => setShowSettings(false)} />

--- a/src/components/finance/MonthPicker.tsx
+++ b/src/components/finance/MonthPicker.tsx
@@ -1,0 +1,36 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { TouchableOpacity, View, Text } from 'react-native';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { monthLabel } from '@/utils/historyUtils';
+
+interface Props {
+  month: string;       // 'YYYY-MM'
+  onPrev: () => void;
+  onNext: () => void;
+  disableNext: boolean; // true when already at the newest available month
+}
+
+export function MonthPicker({ month, onPrev, onNext, disableNext }: Props) {
+  const theme = useAppTheme();
+  return (
+    <View className="flex-row items-center justify-between px-1 py-2">
+      <TouchableOpacity testID="month-picker-prev" onPress={onPrev} className="p-2">
+        <Ionicons name="chevron-back" size={20} color={theme.primary} />
+      </TouchableOpacity>
+      <Text className="text-sm font-semibold" style={{ color: theme.text }}>
+        {monthLabel(month)}
+      </Text>
+      <TouchableOpacity
+        testID="month-picker-next"
+        onPress={onNext}
+        disabled={disableNext}
+        className="p-2">
+        <Ionicons
+          name="chevron-forward"
+          size={20}
+          color={disableNext ? theme.textSubtle : theme.primary}
+        />
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/src/components/finance/__tests__/MonthPicker.test.tsx
+++ b/src/components/finance/__tests__/MonthPicker.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { MonthPicker } from '../MonthPicker';
+
+jest.mock('@expo/vector-icons/Ionicons', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  const { Text } = jest.requireActual('react-native') as typeof import('react-native');
+  return {
+    __esModule: true,
+    default: ({ name, testID }: { name?: string; testID?: string }) =>
+      React.createElement(Text, { testID: testID ?? `icon-${name}` }, name),
+  };
+});
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    primary: '#007AFF',
+    surface: '#FFFFFF',
+    border: '#E0E0E0',
+    text: '#000000',
+    textMuted: '#666666',
+    textSubtle: '#999999',
+  }),
+}));
+
+describe('MonthPicker', () => {
+  it('renders the formatted month label', () => {
+    const { getByText } = render(
+      <MonthPicker month="2026-03" onPrev={jest.fn()} onNext={jest.fn()} disableNext={false} />
+    );
+    expect(getByText('March 2026')).toBeTruthy();
+  });
+
+  it('calls onPrev when the left chevron is pressed', () => {
+    const onPrev = jest.fn();
+    const { getByTestId } = render(
+      <MonthPicker month="2026-03" onPrev={onPrev} onNext={jest.fn()} disableNext={false} />
+    );
+    fireEvent.press(getByTestId('month-picker-prev'));
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onNext when the right chevron is pressed', () => {
+    const onNext = jest.fn();
+    const { getByTestId } = render(
+      <MonthPicker month="2026-03" onPrev={jest.fn()} onNext={onNext} disableNext={false} />
+    );
+    fireEvent.press(getByTestId('month-picker-next'));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the next button when disableNext is true', () => {
+    const onNext = jest.fn();
+    const { getByTestId } = render(
+      <MonthPicker month="2026-03" onPrev={jest.fn()} onNext={onNext} disableNext={true} />
+    );
+    fireEvent.press(getByTestId('month-picker-next'));
+    expect(onNext).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/historyUtils.test.ts
+++ b/src/utils/__tests__/historyUtils.test.ts
@@ -1,0 +1,51 @@
+import {
+  prevMonth,
+  nextMonth,
+  monthLabel,
+  availableMonths,
+} from '../historyUtils';
+
+describe('prevMonth', () => {
+  it('goes back one month within the same year', () => {
+    expect(prevMonth('2026-03')).toBe('2026-02');
+  });
+
+  it('wraps back to December of the previous year', () => {
+    expect(prevMonth('2026-01')).toBe('2025-12');
+  });
+});
+
+describe('nextMonth', () => {
+  it('advances one month within the same year', () => {
+    expect(nextMonth('2026-02')).toBe('2026-03');
+  });
+
+  it('wraps forward to January of the next year', () => {
+    expect(nextMonth('2025-12')).toBe('2026-01');
+  });
+});
+
+describe('monthLabel', () => {
+  it('formats YYYY-MM as "Month YYYY"', () => {
+    expect(monthLabel('2026-03')).toBe('March 2026');
+  });
+
+  it('formats January correctly', () => {
+    expect(monthLabel('2025-01')).toBe('January 2025');
+  });
+});
+
+describe('availableMonths', () => {
+  it('returns empty array when there are no expenses', () => {
+    expect(availableMonths([])).toEqual([]);
+  });
+
+  it('returns unique months sorted newest-first', () => {
+    const expenses = [
+      { id: 'e1', categoryId: 'c1', amount: 10, date: new Date('2026-03-15').getTime() },
+      { id: 'e2', categoryId: 'c1', amount: 20, date: new Date('2026-01-05').getTime() },
+      { id: 'e3', categoryId: 'c1', amount: 5,  date: new Date('2026-03-01').getTime() },
+    ];
+    expect(availableMonths(expenses)).toEqual(['2026-03', '2026-01']);
+  });
+});

--- a/src/utils/historyUtils.ts
+++ b/src/utils/historyUtils.ts
@@ -1,0 +1,30 @@
+import type { Expense } from '@/models/finance';
+
+/** Returns the previous month as 'YYYY-MM' */
+export function prevMonth(month: string): string {
+  const [y, m] = month.split('-').map(Number);
+  if (m === 1) return `${y - 1}-12`;
+  return `${y}-${String(m - 1).padStart(2, '0')}`;
+}
+
+/** Returns the next month as 'YYYY-MM' */
+export function nextMonth(month: string): string {
+  const [y, m] = month.split('-').map(Number);
+  if (m === 12) return `${y + 1}-01`;
+  return `${y}-${String(m + 1).padStart(2, '0')}`;
+}
+
+/** Formats 'YYYY-MM' as a human-readable label, e.g. 'March 2026' */
+export function monthLabel(month: string): string {
+  const [year, m] = month.split('-').map(Number);
+  return new Date(year, m - 1, 1).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+}
+
+/**
+ * Returns the unique months represented in the expense list,
+ * sorted newest-first, as 'YYYY-MM' strings.
+ */
+export function availableMonths(expenses: Expense[]): string[] {
+  const set = new Set(expenses.map((e) => new Date(e.date).toISOString().slice(0, 7)));
+  return Array.from(set).sort((a, b) => b.localeCompare(a));
+}


### PR DESCRIPTION
Closes #9

## Summary

- 📅 **History section** added below the current month on the finances screen — only visible when there are past months with expenses
- 🔁 **MonthPicker** component with prev/next chevrons to navigate between past months
- 📊 Shows category budget progress bars + individual expense items for the selected month
- 🔄 History month selection resets correctly when switching between spaces

## What was built

- `src/utils/historyUtils.ts` — pure helpers: `prevMonth`, `nextMonth`, `monthLabel`, `availableMonths`
- `src/components/finance/MonthPicker.tsx` — reusable month navigation component
- `app/(tabs)/finances.tsx` — history section integrated into the existing screen

## Tests

18 new tests added (676 total, all passing)