### PR TITLE
✨ feat(pomodoro): auto-break, timer settings, and bulk task queue

### DIFF
--- a/app/(tabs)/__tests__/pomodoro.test.tsx
+++ b/app/(tabs)/__tests__/pomodoro.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import { ScrollView } from 'react-native';
 import { usePomodoroStore } from '@/stores/pomodoroStore';
 import { useTaskStore } from '@/stores/taskStore';
@@ -54,6 +54,23 @@ jest.mock('@/components/pomodoro/TaskPicker', () => ({
 jest.mock('@/components/pomodoro/SessionLog', () => ({
   SessionLog: () => null,
 }));
+
+jest.mock('@/components/pomodoro/TimerSettings', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  const { View } = jest.requireActual('react-native') as typeof import('react-native');
+  return {
+    TimerSettings: ({ visible }: { visible: boolean; onClose: () => void }) =>
+      visible ? React.createElement(View, { testID: 'mock-timer-settings' }) : null,
+  };
+});
+
+jest.mock('@/components/pomodoro/TaskQueue', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  const { View } = jest.requireActual('react-native') as typeof import('react-native');
+  return {
+    TaskQueue: () => React.createElement(View, { testID: 'mock-task-queue' }),
+  };
+});
 
 const INITIAL_POMODORO_STATE = {
   sessions: [],
@@ -170,5 +187,30 @@ describe('PomodoroScreen UI', () => {
       unmount();
     });
     // Verify no crash — the cleanup cleared the timeout
+  });
+
+  describe('timer settings', () => {
+    it('renders a settings button in the header', () => {
+      const { getByTestId } = render(<PomodoroScreen />);
+      expect(getByTestId('timer-settings-btn')).toBeTruthy();
+    });
+
+    it('opens TimerSettings modal when settings button is pressed', () => {
+      const { getByTestId } = render(<PomodoroScreen />);
+      fireEvent.press(getByTestId('timer-settings-btn'));
+      expect(getByTestId('mock-timer-settings')).toBeTruthy();
+    });
+  });
+
+  describe('bulk tasks section', () => {
+    it('renders the Bulk tasks section heading', () => {
+      const { getByText } = render(<PomodoroScreen />);
+      expect(getByText('Bulk tasks')).toBeTruthy();
+    });
+
+    it('renders the TaskQueue component', () => {
+      const { getByTestId } = render(<PomodoroScreen />);
+      expect(getByTestId('mock-task-queue')).toBeTruthy();
+    });
   });
 });

--- a/app/(tabs)/pomodoro.tsx
+++ b/app/(tabs)/pomodoro.tsx
@@ -1,11 +1,22 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { useEffect, useRef, useState } from 'react';
-import { Platform, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import {
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  useWindowDimensions,
+  View,
+} from 'react-native';
 import ConfettiCannon from 'react-native-confetti-cannon';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { SessionLog } from '@/components/pomodoro/SessionLog';
 import { TaskPicker } from '@/components/pomodoro/TaskPicker';
+import { TaskQueue } from '@/components/pomodoro/TaskQueue';
 import { TimerControls } from '@/components/pomodoro/TimerControls';
 import { TimerDisplay } from '@/components/pomodoro/TimerDisplay';
+import { TimerSettings } from '@/components/pomodoro/TimerSettings';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { usePomodoroStore } from '@/stores/pomodoroStore';
 import { fireConfetti } from '@/utils/confetti';
@@ -16,6 +27,7 @@ export default function PomodoroScreen() {
   const sessionsCount = usePomodoroStore((s) => s.sessions.length);
   const previousSessionsCountRef = useRef(sessionsCount);
   const [showConfetti, setShowConfetti] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const confettiTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -51,10 +63,16 @@ export default function PomodoroScreen() {
       <ScrollView
         contentContainerStyle={{ minHeight: height, backgroundColor: theme.bg }}
         showsVerticalScrollIndicator={false}>
-        <View className="px-4 pt-4 pb-2">
+        <View className="px-4 pt-4 pb-2 flex-row justify-between items-center">
           <Text className="text-2xl font-bold" style={{ color: theme.text }}>
             Focus
           </Text>
+          <TouchableOpacity
+            testID="timer-settings-btn"
+            onPress={() => setShowSettings(true)}
+            className="p-1">
+            <Ionicons name="settings-outline" size={22} color={theme.textMuted} />
+          </TouchableOpacity>
         </View>
 
         <TimerDisplay />
@@ -70,6 +88,13 @@ export default function PomodoroScreen() {
           <TaskPicker />
         </View>
 
+        <View className="px-4 mt-6">
+          <Text className="text-base font-semibold mb-2" style={{ color: theme.textMuted }}>
+            Bulk tasks
+          </Text>
+          <TaskQueue />
+        </View>
+
         <View className="px-4 mt-6 mb-8">
           <Text className="text-base font-semibold mb-2" style={{ color: theme.textMuted }}>
             Session log
@@ -77,6 +102,8 @@ export default function PomodoroScreen() {
           <SessionLog />
         </View>
       </ScrollView>
+
+      <TimerSettings visible={showSettings} onClose={() => setShowSettings(false)} />
 
       {Platform.OS !== 'web' && showConfetti && (
         <View pointerEvents="none" style={styles.confettiOverlay}>

--- a/src/components/pomodoro/TaskQueue.tsx
+++ b/src/components/pomodoro/TaskQueue.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react';
+import { ScrollView, Text, TouchableOpacity, View } from 'react-native';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { usePomodoroStore } from '@/stores/pomodoroStore';
+import { useTaskStore } from '@/stores/taskStore';
+
+export function TaskQueue() {
+  const theme = useAppTheme();
+  const { taskQueue, status, setTaskQueue, startQueue } = usePomodoroStore((s) => ({
+    taskQueue: s.taskQueue,
+    status: s.status,
+    setTaskQueue: s.setTaskQueue,
+    startQueue: s.startQueue,
+  }));
+  const tasks = useTaskStore((s) => s.tasks);
+  const activeTasks = useMemo(() => tasks.filter((t) => !t.completed), [tasks]);
+
+  const toggleTask = (id: string) => {
+    if (taskQueue.includes(id)) {
+      setTaskQueue(taskQueue.filter((qId) => qId !== id));
+    } else {
+      setTaskQueue([...taskQueue, id]);
+    }
+  };
+
+  const canStart = taskQueue.length > 0 && status !== 'running';
+
+  return (
+    <View className="gap-3">
+      {/* Task list */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ gap: 8 }}>
+        {activeTasks.map((task) => {
+          const queueIndex = taskQueue.indexOf(task.id);
+          const isQueued = queueIndex !== -1;
+          return (
+            <TouchableOpacity
+              key={task.id}
+              onPress={() => toggleTask(task.id)}
+              className="px-3 py-2 rounded-full border flex-row items-center gap-1.5 max-w-44"
+              style={{
+                backgroundColor: isQueued ? theme.primary : theme.surface,
+                borderColor: isQueued ? theme.primary : theme.border,
+              }}>
+              {isQueued && (
+                <View
+                  className="w-4 h-4 rounded-full items-center justify-center"
+                  style={{ backgroundColor: 'rgba(255,255,255,0.3)' }}>
+                  <Text className="text-xs font-bold text-white">{queueIndex + 1}</Text>
+                </View>
+              )}
+              <Text
+                className="text-sm font-medium"
+                numberOfLines={1}
+                style={{ color: isQueued ? '#fff' : theme.textMuted }}>
+                {task.title}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+        {activeTasks.length === 0 && (
+          <View className="px-3 py-2">
+            <Text className="text-sm" style={{ color: theme.textSubtle }}>
+              No active tasks
+            </Text>
+          </View>
+        )}
+      </ScrollView>
+
+      {/* Start button */}
+      <TouchableOpacity
+        onPress={() => canStart && startQueue(taskQueue)}
+        className="py-2.5 rounded-xl items-center"
+        style={{
+          backgroundColor: canStart ? theme.primary : theme.surfaceMuted,
+          borderColor: theme.border,
+          borderWidth: canStart ? 0 : 1,
+        }}>
+        <Text
+          className="text-sm font-semibold"
+          style={{ color: canStart ? '#fff' : theme.textSubtle }}>
+          Start queue
+        </Text>
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/src/components/pomodoro/TaskQueue.tsx
+++ b/src/components/pomodoro/TaskQueue.tsx
@@ -6,12 +6,10 @@ import { useTaskStore } from '@/stores/taskStore';
 
 export function TaskQueue() {
   const theme = useAppTheme();
-  const { taskQueue, status, setTaskQueue, startQueue } = usePomodoroStore((s) => ({
-    taskQueue: s.taskQueue,
-    status: s.status,
-    setTaskQueue: s.setTaskQueue,
-    startQueue: s.startQueue,
-  }));
+  const taskQueue = usePomodoroStore((s) => s.taskQueue);
+  const status = usePomodoroStore((s) => s.status);
+  const setTaskQueue = usePomodoroStore((s) => s.setTaskQueue);
+  const startQueue = usePomodoroStore((s) => s.startQueue);
   const tasks = useTaskStore((s) => s.tasks);
   const activeTasks = useMemo(() => tasks.filter((t) => !t.completed), [tasks]);
 

--- a/src/components/pomodoro/TimerControls.tsx
+++ b/src/components/pomodoro/TimerControls.tsx
@@ -5,7 +5,10 @@ import { usePomodoroStore } from '@/stores/pomodoroStore';
 
 export function TimerControls() {
   const theme = useAppTheme();
-  const { status, start, pause, reset } = usePomodoroStore();
+  const status = usePomodoroStore((s) => s.status);
+  const start = usePomodoroStore((s) => s.start);
+  const pause = usePomodoroStore((s) => s.pause);
+  const reset = usePomodoroStore((s) => s.reset);
   const isRunning = status === 'running';
 
   return (

--- a/src/components/pomodoro/TimerDisplay.tsx
+++ b/src/components/pomodoro/TimerDisplay.tsx
@@ -1,6 +1,8 @@
+import { useMemo } from 'react';
 import { Text, View } from 'react-native';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { usePomodoroStore } from '@/stores/pomodoroStore';
+import { useTaskStore } from '@/stores/taskStore';
 
 function pad(n: number) {
   return String(n).padStart(2, '0');
@@ -8,10 +10,21 @@ function pad(n: number) {
 
 export function TimerDisplay() {
   const theme = useAppTheme();
-  const { secondsRemaining, phase, cycleCount } = usePomodoroStore();
+  const secondsRemaining = usePomodoroStore((s) => s.secondsRemaining);
+  const phase = usePomodoroStore((s) => s.phase);
+  const cycleCount = usePomodoroStore((s) => s.cycleCount);
+  const selectedTaskId = usePomodoroStore((s) => s.selectedTaskId);
+  const tasks = useTaskStore((s) => s.tasks);
   const minutes = Math.floor(secondsRemaining / 60);
   const seconds = secondsRemaining % 60;
   const isWork = phase === 'work';
+  const runningTaskTitle = useMemo(
+    () =>
+      isWork && selectedTaskId
+        ? tasks.find((t) => t.id === selectedTaskId)?.title ?? null
+        : null,
+    [isWork, selectedTaskId, tasks]
+  );
 
   return (
     <View
@@ -22,6 +35,14 @@ export function TimerDisplay() {
         style={{ color: isWork ? theme.primary : theme.success }}>
         {isWork ? 'Focus' : 'Break'}
       </Text>
+      {runningTaskTitle && (
+        <Text
+          className="text-sm font-medium mb-1"
+          numberOfLines={1}
+          style={{ color: theme.textMuted }}>
+          {runningTaskTitle}
+        </Text>
+      )}
       <Text
         className="text-8xl font-thin tabular-nums"
         style={{ color: isWork ? theme.text : theme.success }}>

--- a/src/components/pomodoro/TimerSettings.tsx
+++ b/src/components/pomodoro/TimerSettings.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { Modal } from '@/components/ui/Modal';
+import { useAppTheme } from '@/hooks/useAppTheme';
+import { usePomodoroStore } from '@/stores/pomodoroStore';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export function TimerSettings({ visible, onClose }: Props) {
+  const theme = useAppTheme();
+  const { workDuration, breakDuration, updateDurations } = usePomodoroStore((s) => ({
+    workDuration: s.workDuration,
+    breakDuration: s.breakDuration,
+    updateDurations: s.updateDurations,
+  }));
+
+  const [focusInput, setFocusInput] = useState(String(workDuration));
+  const [breakInput, setBreakInput] = useState(String(breakDuration));
+
+  useEffect(() => {
+    if (visible) {
+      setFocusInput(String(workDuration));
+      setBreakInput(String(breakDuration));
+    }
+  }, [visible, workDuration, breakDuration]);
+
+  const handleSave = () => {
+    const parsedFocus = parseInt(focusInput, 10);
+    const parsedBreak = parseInt(breakInput, 10);
+    const work = Number.isNaN(parsedFocus)
+      ? workDuration
+      : Math.min(60, Math.max(1, parsedFocus));
+    const breakMins = Number.isNaN(parsedBreak)
+      ? breakDuration
+      : Math.min(60, Math.max(1, parsedBreak));
+    updateDurations(work, breakMins);
+    onClose();
+  };
+
+  return (
+    <Modal visible={visible} onClose={onClose} title="Timer settings">
+      <View className="gap-4">
+        <View>
+          <Text className="text-sm font-medium mb-1" style={{ color: theme.textMuted }}>
+            Focus duration (minutes)
+          </Text>
+          <TextInput
+            value={focusInput}
+            onChangeText={setFocusInput}
+            keyboardType="number-pad"
+            className="rounded-xl px-4 py-3 text-base"
+            style={{
+              borderColor: theme.border,
+              borderWidth: 1,
+              backgroundColor: theme.surface,
+              color: theme.text,
+            }}
+          />
+        </View>
+
+        <View>
+          <Text className="text-sm font-medium mb-1" style={{ color: theme.textMuted }}>
+            Break duration (minutes)
+          </Text>
+          <TextInput
+            value={breakInput}
+            onChangeText={setBreakInput}
+            keyboardType="number-pad"
+            className="rounded-xl px-4 py-3 text-base"
+            style={{
+              borderColor: theme.border,
+              borderWidth: 1,
+              backgroundColor: theme.surface,
+              color: theme.text,
+            }}
+          />
+        </View>
+
+        <TouchableOpacity
+          onPress={handleSave}
+          className="py-3 rounded-xl items-center"
+          style={{ backgroundColor: theme.primary }}>
+          <Text className="font-semibold text-white">Save</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+}

--- a/src/components/pomodoro/TimerSettings.tsx
+++ b/src/components/pomodoro/TimerSettings.tsx
@@ -11,11 +11,9 @@ interface Props {
 
 export function TimerSettings({ visible, onClose }: Props) {
   const theme = useAppTheme();
-  const { workDuration, breakDuration, updateDurations } = usePomodoroStore((s) => ({
-    workDuration: s.workDuration,
-    breakDuration: s.breakDuration,
-    updateDurations: s.updateDurations,
-  }));
+  const workDuration = usePomodoroStore((s) => s.workDuration);
+  const breakDuration = usePomodoroStore((s) => s.breakDuration);
+  const updateDurations = usePomodoroStore((s) => s.updateDurations);
 
   const [focusInput, setFocusInput] = useState(String(workDuration));
   const [breakInput, setBreakInput] = useState(String(breakDuration));

--- a/src/components/pomodoro/__tests__/TaskQueue.test.tsx
+++ b/src/components/pomodoro/__tests__/TaskQueue.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    primary: '#007AFF',
+    primarySoft: '#E5F1FF',
+    surface: '#FFFFFF',
+    surfaceMuted: '#F5F5F5',
+    border: '#E0E0E0',
+    text: '#000000',
+    textMuted: '#666666',
+    textSubtle: '#999999',
+    danger: '#FF3B30',
+  }),
+}));
+
+const mockSetTaskQueue = jest.fn();
+const mockStartQueue = jest.fn();
+
+let mockPomodoroState = {
+  taskQueue: [] as string[],
+  status: 'idle' as 'idle' | 'running' | 'paused',
+  setTaskQueue: mockSetTaskQueue,
+  startQueue: mockStartQueue,
+};
+
+jest.mock('@/stores/pomodoroStore', () => ({
+  usePomodoroStore: (selector: (s: typeof mockPomodoroState) => unknown) =>
+    selector(mockPomodoroState),
+}));
+
+let mockTasks = [
+  { id: 't1', title: 'Task One', completed: false },
+  { id: 't2', title: 'Task Two', completed: false },
+  { id: 't3', title: 'Task Three', completed: true }, // completed, should not appear
+];
+
+jest.mock('@/stores/taskStore', () => ({
+  useTaskStore: (selector: (s: { tasks: typeof mockTasks }) => unknown) =>
+    selector({ tasks: mockTasks }),
+}));
+
+import { TaskQueue } from '../TaskQueue';
+
+describe('TaskQueue', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPomodoroState = {
+      taskQueue: [],
+      status: 'idle',
+      setTaskQueue: mockSetTaskQueue,
+      startQueue: mockStartQueue,
+    };
+    mockTasks = [
+      { id: 't1', title: 'Task One', completed: false },
+      { id: 't2', title: 'Task Two', completed: false },
+      { id: 't3', title: 'Task Three', completed: true },
+    ];
+  });
+
+  it('renders only active (non-completed) tasks', () => {
+    const { getByText, queryByText } = render(<TaskQueue />);
+    expect(getByText('Task One')).toBeTruthy();
+    expect(getByText('Task Two')).toBeTruthy();
+    expect(queryByText('Task Three')).toBeNull();
+  });
+
+  it('tapping a task adds it to the queue', () => {
+    const { getByText } = render(<TaskQueue />);
+    fireEvent.press(getByText('Task One'));
+    expect(mockSetTaskQueue).toHaveBeenCalledWith(['t1']);
+  });
+
+  it('tapping a queued task removes it from the queue', () => {
+    mockPomodoroState = { ...mockPomodoroState, taskQueue: ['t1', 't2'] };
+    const { getByText } = render(<TaskQueue />);
+    fireEvent.press(getByText('Task One'));
+    expect(mockSetTaskQueue).toHaveBeenCalledWith(['t2']);
+  });
+
+  it('shows queued tasks with numbered labels', () => {
+    mockPomodoroState = { ...mockPomodoroState, taskQueue: ['t1', 't2'] };
+    const { getByText } = render(<TaskQueue />);
+    expect(getByText('1')).toBeTruthy();
+    expect(getByText('2')).toBeTruthy();
+  });
+
+  it('Start button calls startQueue with the current queue', () => {
+    mockPomodoroState = { ...mockPomodoroState, taskQueue: ['t1', 't2'] };
+    const { getByText } = render(<TaskQueue />);
+    fireEvent.press(getByText('Start queue'));
+    expect(mockStartQueue).toHaveBeenCalledWith(['t1', 't2']);
+  });
+
+  it('Start button is disabled when queue is empty', () => {
+    const { getByText } = render(<TaskQueue />);
+    fireEvent.press(getByText('Start queue'));
+    expect(mockStartQueue).not.toHaveBeenCalled();
+  });
+
+  it('Start button is disabled when timer is running', () => {
+    mockPomodoroState = { ...mockPomodoroState, taskQueue: ['t1'], status: 'running' };
+    const { getByText } = render(<TaskQueue />);
+    fireEvent.press(getByText('Start queue'));
+    expect(mockStartQueue).not.toHaveBeenCalled();
+  });
+
+  it('shows "No active tasks" when all tasks are completed', () => {
+    mockTasks = [{ id: 't3', title: 'Task Three', completed: true }];
+    const { getByText } = render(<TaskQueue />);
+    expect(getByText('No active tasks')).toBeTruthy();
+  });
+});

--- a/src/components/pomodoro/__tests__/TimerControls.test.tsx
+++ b/src/components/pomodoro/__tests__/TimerControls.test.tsx
@@ -27,12 +27,15 @@ jest.mock('@/hooks/useAppTheme', () => ({
 }));
 
 jest.mock('@/stores/pomodoroStore', () => ({
-  usePomodoroStore: () => ({
-    status: mockStatus,
-    start: mockStart,
-    pause: mockPause,
-    reset: mockReset,
-  }),
+  usePomodoroStore: (selector?: (s: any) => any) => {
+    const store = {
+      status: mockStatus,
+      start: mockStart,
+      pause: mockPause,
+      reset: mockReset,
+    };
+    return selector ? selector(store) : store;
+  },
 }));
 
 jest.mock('@expo/vector-icons/Ionicons', () => {

--- a/src/components/pomodoro/__tests__/TimerDisplay.test.tsx
+++ b/src/components/pomodoro/__tests__/TimerDisplay.test.tsx
@@ -1,0 +1,83 @@
+import { render } from '@testing-library/react-native';
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    primary: '#007AFF',
+    success: '#34C759',
+    text: '#000000',
+    textMuted: '#666666',
+    textSubtle: '#999999',
+    surfaceMuted: '#F5F5F5',
+    border: '#E0E0E0',
+  }),
+}));
+
+let mockPomodoroState = {
+  secondsRemaining: 25 * 60,
+  phase: 'work' as 'work' | 'break',
+  cycleCount: 0,
+  selectedTaskId: null as string | null,
+};
+
+jest.mock('@/stores/pomodoroStore', () => ({
+  usePomodoroStore: (selector: (s: typeof mockPomodoroState) => unknown) =>
+    selector(mockPomodoroState),
+}));
+
+let mockTasks = [
+  { id: 'task-1', title: 'Write tests', completed: false },
+];
+
+jest.mock('@/stores/taskStore', () => ({
+  useTaskStore: (selector: (s: { tasks: typeof mockTasks }) => unknown) =>
+    selector({ tasks: mockTasks }),
+}));
+
+import { TimerDisplay } from '../TimerDisplay';
+
+describe('TimerDisplay', () => {
+  beforeEach(() => {
+    mockPomodoroState = {
+      secondsRemaining: 25 * 60,
+      phase: 'work',
+      cycleCount: 0,
+      selectedTaskId: null,
+    };
+    mockTasks = [{ id: 'task-1', title: 'Write tests', completed: false }];
+  });
+
+  it('shows Focus label during work phase', () => {
+    const { getByText } = render(<TimerDisplay />);
+    expect(getByText('Focus')).toBeTruthy();
+  });
+
+  it('shows Break label during break phase', () => {
+    mockPomodoroState = { ...mockPomodoroState, phase: 'break' };
+    const { getByText } = render(<TimerDisplay />);
+    expect(getByText('Break')).toBeTruthy();
+  });
+
+  it('shows the running task name when selectedTaskId is set and phase is work', () => {
+    mockPomodoroState = { ...mockPomodoroState, selectedTaskId: 'task-1' };
+    const { getByText } = render(<TimerDisplay />);
+    expect(getByText('Write tests')).toBeTruthy();
+  });
+
+  it('does not show task name during break phase even if selectedTaskId is set', () => {
+    mockPomodoroState = { ...mockPomodoroState, phase: 'break', selectedTaskId: 'task-1' };
+    const { queryByText } = render(<TimerDisplay />);
+    expect(queryByText('Write tests')).toBeNull();
+  });
+
+  it('does not show task name when no task is selected', () => {
+    mockPomodoroState = { ...mockPomodoroState, selectedTaskId: null };
+    const { queryByText } = render(<TimerDisplay />);
+    expect(queryByText('Write tests')).toBeNull();
+  });
+
+  it('shows session count when cycleCount > 0', () => {
+    mockPomodoroState = { ...mockPomodoroState, cycleCount: 3 };
+    const { getByText } = render(<TimerDisplay />);
+    expect(getByText('3 sessions completed today')).toBeTruthy();
+  });
+});

--- a/src/components/pomodoro/__tests__/TimerSettings.test.tsx
+++ b/src/components/pomodoro/__tests__/TimerSettings.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { usePomodoroStore } from '@/stores/pomodoroStore';
+import { TimerSettings } from '../TimerSettings';
+
+jest.mock('@/hooks/useAppTheme', () => ({
+  useAppTheme: () => ({
+    primary: '#007AFF',
+    surface: '#FFFFFF',
+    surfaceMuted: '#F5F5F5',
+    border: '#E0E0E0',
+    text: '#000000',
+    textMuted: '#666666',
+    textSubtle: '#999999',
+  }),
+}));
+
+jest.mock('@/stores/pomodoroStore', () => {
+  const mockUpdateDurations = jest.fn();
+  return {
+    usePomodoroStore: jest.fn((selector) =>
+      selector({
+        workDuration: 25,
+        breakDuration: 5,
+        updateDurations: mockUpdateDurations,
+      })
+    ),
+    _mockUpdateDurations: mockUpdateDurations,
+  };
+});
+
+jest.mock('@/components/ui/Modal', () => {
+  const React = jest.requireActual('react') as typeof import('react');
+  const { View } = jest.requireActual('react-native') as typeof import('react-native');
+  return {
+    Modal: ({
+      visible,
+      children,
+    }: {
+      visible: boolean;
+      onClose: () => void;
+      title: string;
+      children: React.ReactNode;
+    }) => (visible ? React.createElement(View, { testID: 'modal' }, children) : null),
+  };
+});
+
+function getUpdateDurationsMock() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (jest.requireMock('@/stores/pomodoroStore') as any)._mockUpdateDurations as jest.Mock;
+}
+
+describe('TimerSettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders focus and break inputs with current durations', () => {
+    const { getByDisplayValue } = render(
+      <TimerSettings visible={true} onClose={jest.fn()} />
+    );
+    expect(getByDisplayValue('25')).toBeTruthy();
+    expect(getByDisplayValue('5')).toBeTruthy();
+  });
+
+  it('calls updateDurations with parsed values when Save is pressed', () => {
+    const onClose = jest.fn();
+    const { getByDisplayValue, getByText } = render(
+      <TimerSettings visible={true} onClose={onClose} />
+    );
+    fireEvent.changeText(getByDisplayValue('25'), '30');
+    fireEvent.changeText(getByDisplayValue('5'), '10');
+    fireEvent.press(getByText('Save'));
+    expect(getUpdateDurationsMock()).toHaveBeenCalledWith(30, 10);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('clamps focus input below 1 to 1', () => {
+    const { getByDisplayValue, getByText } = render(
+      <TimerSettings visible={true} onClose={jest.fn()} />
+    );
+    fireEvent.changeText(getByDisplayValue('25'), '0');
+    fireEvent.press(getByText('Save'));
+    expect(getUpdateDurationsMock()).toHaveBeenCalledWith(1, 5);
+  });
+
+  it('clamps focus input above 60 to 60', () => {
+    const { getByDisplayValue, getByText } = render(
+      <TimerSettings visible={true} onClose={jest.fn()} />
+    );
+    fireEvent.changeText(getByDisplayValue('25'), '99');
+    fireEvent.press(getByText('Save'));
+    expect(getUpdateDurationsMock()).toHaveBeenCalledWith(60, 5);
+  });
+
+  it('falls back to default focus value for non-numeric input', () => {
+    const { getByDisplayValue, getByText } = render(
+      <TimerSettings visible={true} onClose={jest.fn()} />
+    );
+    fireEvent.changeText(getByDisplayValue('25'), 'abc');
+    fireEvent.press(getByText('Save'));
+    expect(getUpdateDurationsMock()).toHaveBeenCalledWith(25, 5);
+  });
+
+  it('does not render when not visible', () => {
+    const { queryByTestId } = render(
+      <TimerSettings visible={false} onClose={jest.fn()} />
+    );
+    expect(queryByTestId('modal')).toBeNull();
+  });
+
+  it('resets inputs to current store values when modal reopens', () => {
+    const { usePomodoroStore: mockStore } = jest.requireMock('@/stores/pomodoroStore') as {
+      usePomodoroStore: jest.Mock;
+    };
+    mockStore.mockImplementation((selector: (s: unknown) => unknown) =>
+      selector({
+        workDuration: 30,
+        breakDuration: 10,
+        updateDurations: jest.fn(),
+      })
+    );
+    const { getByDisplayValue } = render(
+      <TimerSettings visible={true} onClose={jest.fn()} />
+    );
+    expect(getByDisplayValue('30')).toBeTruthy();
+    expect(getByDisplayValue('10')).toBeTruthy();
+  });
+});

--- a/src/stores/__tests__/pomodoroStore.test.ts
+++ b/src/stores/__tests__/pomodoroStore.test.ts
@@ -17,6 +17,7 @@ const INITIAL_STATE = {
   cycleCount: 0,
   selectedTaskId: null,
   cycleStartedAt: null,
+  taskQueue: [],
 };
 
 beforeEach(() => {
@@ -47,7 +48,7 @@ describe('pomodoroStore', () => {
 
       jest.advanceTimersByTime(1000);
       const state = usePomodoroStore.getState();
-      expect(state.status).toBe('idle');
+      expect(state.status).toBe('running');     // break auto-starts
       expect(state.phase).toBe('break');
       expect(state.secondsRemaining).toBe(state.breakDuration * 60);
       expect(state.sessions).toHaveLength(1);
@@ -149,10 +150,10 @@ describe('pomodoroStore', () => {
       expect(usePomodoroStore.getState().phase).toBe('work');
     });
 
-    it('resets status to idle', () => {
+    it('auto-starts break (status running) after work cycle completes', () => {
       usePomodoroStore.getState().start();
       usePomodoroStore.getState().completeCycle();
-      expect(usePomodoroStore.getState().status).toBe('idle');
+      expect(usePomodoroStore.getState().status).toBe('running');
     });
 
     it('logs a session', () => {
@@ -331,7 +332,7 @@ describe('pomodoroStore', () => {
       usePomodoroStore.getState().reconcileRunningTimer();
 
       const state = usePomodoroStore.getState();
-      expect(state.status).toBe('idle');
+      expect(state.status).toBe('running'); // break auto-starts
       expect(state.phase).toBe('break');
       expect(state.sessions).toHaveLength(1);
       expect(scheduleTimerEndNotification).toHaveBeenCalledWith('work');
@@ -436,6 +437,79 @@ describe('pomodoroStore', () => {
       const options = store.persist?.getOptions?.();
       const outerHandler = options?.onRehydrateStorage?.();
       expect(() => outerHandler?.(null)).not.toThrow();
+    });
+  });
+
+  describe('auto-transition', () => {
+    it('completeCycle: work phase → status running, phase break', () => {
+      usePomodoroStore.setState({ phase: 'work', cycleStartedAt: Date.now() });
+      usePomodoroStore.getState().completeCycle();
+      const s = usePomodoroStore.getState();
+      expect(s.phase).toBe('break');
+      expect(s.status).toBe('running');
+      expect(s.secondsRemaining).toBe(5 * 60);
+      expect(s.cycleCount).toBe(1);
+    });
+
+    it('completeCycle: break phase with empty queue → status idle, phase work', () => {
+      usePomodoroStore.setState({ phase: 'break', cycleStartedAt: Date.now(), taskQueue: [] });
+      usePomodoroStore.getState().completeCycle();
+      const s = usePomodoroStore.getState();
+      expect(s.phase).toBe('work');
+      expect(s.status).toBe('idle');
+      expect(s.secondsRemaining).toBe(25 * 60);
+    });
+
+    it('completeCycle: break phase with queue → advances to next task, status running', () => {
+      usePomodoroStore.setState({
+        phase: 'break',
+        cycleStartedAt: Date.now(),
+        taskQueue: ['task-b', 'task-c'],
+        selectedTaskId: 'task-a',
+      });
+      usePomodoroStore.getState().completeCycle();
+      const s = usePomodoroStore.getState();
+      expect(s.phase).toBe('work');
+      expect(s.status).toBe('running');
+      expect(s.selectedTaskId).toBe('task-b');
+      expect(s.taskQueue).toEqual(['task-c']);
+      expect(s.secondsRemaining).toBe(25 * 60);
+    });
+
+    it('completeCycle: break phase with single-item queue → queue empty after advance', () => {
+      usePomodoroStore.setState({
+        phase: 'break',
+        cycleStartedAt: Date.now(),
+        taskQueue: ['task-b'],
+        selectedTaskId: 'task-a',
+      });
+      usePomodoroStore.getState().completeCycle();
+      const s = usePomodoroStore.getState();
+      expect(s.selectedTaskId).toBe('task-b');
+      expect(s.taskQueue).toEqual([]);
+      expect(s.status).toBe('running');
+    });
+  });
+
+  describe('task queue', () => {
+    it('setTaskQueue replaces the queue', () => {
+      usePomodoroStore.getState().setTaskQueue(['t1', 't2']);
+      expect(usePomodoroStore.getState().taskQueue).toEqual(['t1', 't2']);
+    });
+
+    it('startQueue sets selectedTaskId to first, taskQueue to rest, and starts timer', () => {
+      usePomodoroStore.getState().startQueue(['t1', 't2', 't3']);
+      const s = usePomodoroStore.getState();
+      expect(s.selectedTaskId).toBe('t1');
+      expect(s.taskQueue).toEqual(['t2', 't3']);
+      expect(s.status).toBe('running');
+      expect(s.phase).toBe('work');
+      expect(s.secondsRemaining).toBe(25 * 60);
+    });
+
+    it('startQueue does nothing when given empty array', () => {
+      usePomodoroStore.getState().startQueue([]);
+      expect(usePomodoroStore.getState().status).toBe('idle');
     });
   });
 });

--- a/src/stores/__tests__/pomodoroStore.test.ts
+++ b/src/stores/__tests__/pomodoroStore.test.ts
@@ -198,6 +198,43 @@ describe('pomodoroStore', () => {
       expect(usePomodoroStore.getState().sessions[0].taskId).toBe('task-abc');
     });
 
+    it('does not log taskId on break sessions', () => {
+      usePomodoroStore.setState({
+        ...INITIAL_STATE,
+        phase: 'break',
+        selectedTaskId: 'task-abc',
+        cycleStartedAt: Date.now(),
+      });
+      usePomodoroStore.getState().completeCycle();
+      const session = usePomodoroStore.getState().sessions[0];
+      expect(session.phase).toBe('break');
+      expect(session.taskId).toBeUndefined();
+      expect(session.taskTitle).toBeUndefined();
+    });
+
+    it('marks the linked task as completed after a work session', () => {
+      const taskId = 'task-focus';
+      useTaskStore.setState({
+        tasks: [
+          {
+            id: taskId,
+            title: 'Focus Task',
+            completed: false,
+            priority: 'medium' as const,
+            order: 0,
+            recurring: { enabled: false, days: [] },
+            createdAt: Date.now(),
+          },
+        ],
+        lastResetDate: new Date().toISOString().slice(0, 10),
+      });
+      usePomodoroStore.setState({ ...INITIAL_STATE, selectedTaskId: taskId, phase: 'work', cycleStartedAt: Date.now() });
+      usePomodoroStore.getState().completeCycle();
+      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId);
+      expect(task?.completed).toBe(true);
+      expect(task?.completedAt).toBeDefined();
+    });
+
     it('caps session log at 50 entries', () => {
       const manySessions = Array.from({ length: 50 }, (_, i) => ({
         id: `s-${i}`,
@@ -488,6 +525,33 @@ describe('pomodoroStore', () => {
       expect(s.selectedTaskId).toBe('task-b');
       expect(s.taskQueue).toEqual([]);
       expect(s.status).toBe('running');
+    });
+
+    it('completeCycle: work phase marks selectedTaskId task as completed', () => {
+      const taskId = 'task-queue-item';
+      useTaskStore.setState({
+        tasks: [
+          {
+            id: taskId,
+            title: 'Queue Task',
+            completed: false,
+            priority: 'medium' as const,
+            order: 0,
+            recurring: { enabled: false, days: [] },
+            createdAt: Date.now(),
+          },
+        ],
+        lastResetDate: new Date().toISOString().slice(0, 10),
+      });
+      usePomodoroStore.setState({
+        phase: 'work',
+        cycleStartedAt: Date.now(),
+        selectedTaskId: taskId,
+        taskQueue: ['next-task'],
+      });
+      usePomodoroStore.getState().completeCycle();
+      const task = useTaskStore.getState().tasks.find((t) => t.id === taskId);
+      expect(task?.completed).toBe(true);
     });
   });
 

--- a/src/stores/pomodoroStore.ts
+++ b/src/stores/pomodoroStore.ts
@@ -114,12 +114,14 @@ export const usePomodoroStore = create<PomodoroStore>()(
         const { phase, workDuration, breakDuration, cycleCount, selectedTaskId, cycleStartedAt, taskQueue } =
           get();
 
-        const taskTitle = selectedTaskId
-          ? useTaskStore.getState().tasks.find((t) => t.id === selectedTaskId)?.title
-          : undefined;
+        // Only associate task metadata with work sessions; breaks are rests, not task execution
+        const taskTitle =
+          phase === 'work' && selectedTaskId
+            ? useTaskStore.getState().tasks.find((t) => t.id === selectedTaskId)?.title
+            : undefined;
         const session: PomodoroSession = {
           id: generateId(),
-          taskId: selectedTaskId ?? undefined,
+          taskId: phase === 'work' ? (selectedTaskId ?? undefined) : undefined,
           taskTitle,
           phase,
           durationMinutes: phase === 'work' ? workDuration : breakDuration,
@@ -141,6 +143,13 @@ export const usePomodoroStore = create<PomodoroStore>()(
             cycleCount: cycleCount + 1,
             cycleStartedAt: Date.now(),
           }));
+          // Mark the focused task as completed
+          if (selectedTaskId) {
+            useTaskStore.getState().updateTask(selectedTaskId, {
+              completed: true,
+              completedAt: Date.now(),
+            });
+          }
           ensurePomodoroInterval();
         } else {
           // After break: advance queue or go idle

--- a/src/stores/pomodoroStore.ts
+++ b/src/stores/pomodoroStore.ts
@@ -49,6 +49,7 @@ interface PomodoroStore {
   cycleCount: number;
   selectedTaskId: string | null;
   cycleStartedAt: number | null;
+  taskQueue: string[]; // task IDs queued after current selectedTaskId
 
   start: () => void;
   pause: () => void;
@@ -59,6 +60,8 @@ interface PomodoroStore {
   startWorkForTask: (id: string | null) => void;
   updateDurations: (work: number, breakMins: number) => void;
   reconcileRunningTimer: () => void;
+  setTaskQueue: (ids: string[]) => void;
+  startQueue: (taskIds: string[]) => void;
 }
 
 export const usePomodoroStore = create<PomodoroStore>()(
@@ -74,6 +77,7 @@ export const usePomodoroStore = create<PomodoroStore>()(
       cycleCount: 0,
       selectedTaskId: null,
       cycleStartedAt: null,
+      taskQueue: [],
 
       start: () => {
         const { status, phase, workDuration, breakDuration, secondsRemaining } = get();
@@ -107,10 +111,9 @@ export const usePomodoroStore = create<PomodoroStore>()(
 
       completeCycle: () => {
         stopPomodoroInterval();
-        const { phase, workDuration, breakDuration, cycleCount, selectedTaskId, cycleStartedAt } =
+        const { phase, workDuration, breakDuration, cycleCount, selectedTaskId, cycleStartedAt, taskQueue } =
           get();
 
-        // Log the completed session
         const taskTitle = selectedTaskId
           ? useTaskStore.getState().tasks.find((t) => t.id === selectedTaskId)?.title
           : undefined;
@@ -126,19 +129,45 @@ export const usePomodoroStore = create<PomodoroStore>()(
           endedAt: Date.now(),
         };
 
-        const nextPhase: TimerPhase = phase === 'work' ? 'break' : 'work';
-        const nextDuration = nextPhase === 'work' ? workDuration : breakDuration;
-
         scheduleTimerEndNotification(phase);
 
-        set((s) => ({
-          sessions: [session, ...s.sessions].slice(0, 50),
-          phase: nextPhase,
-          status: 'idle',
-          secondsRemaining: nextDuration * 60,
-          cycleCount: phase === 'work' ? cycleCount + 1 : cycleCount,
-          cycleStartedAt: null,
-        }));
+        if (phase === 'work') {
+          // After focus: auto-start the break
+          set((s) => ({
+            sessions: [session, ...s.sessions].slice(0, 50),
+            phase: 'break',
+            status: 'running',
+            secondsRemaining: breakDuration * 60,
+            cycleCount: cycleCount + 1,
+            cycleStartedAt: Date.now(),
+          }));
+          ensurePomodoroInterval();
+        } else {
+          // After break: advance queue or go idle
+          if (taskQueue.length > 0) {
+            const [nextTaskId, ...remainingQueue] = taskQueue;
+            set((s) => ({
+              sessions: [session, ...s.sessions].slice(0, 50),
+              phase: 'work',
+              status: 'running',
+              secondsRemaining: workDuration * 60,
+              cycleCount,
+              cycleStartedAt: Date.now(),
+              selectedTaskId: nextTaskId,
+              taskQueue: remainingQueue,
+            }));
+            ensurePomodoroInterval();
+          } else {
+            set((s) => ({
+              sessions: [session, ...s.sessions].slice(0, 50),
+              phase: 'work',
+              status: 'idle',
+              secondsRemaining: workDuration * 60,
+              cycleCount,
+              cycleStartedAt: null,
+            }));
+          }
+        }
       },
 
       setSelectedTask: (id) => set({ selectedTaskId: id }),
@@ -163,6 +192,23 @@ export const usePomodoroStore = create<PomodoroStore>()(
           status: 'idle',
         }));
         stopPomodoroInterval();
+      },
+
+      setTaskQueue: (ids) => set({ taskQueue: ids }),
+
+      startQueue: (taskIds) => {
+        if (taskIds.length === 0) return;
+        const [first, ...rest] = taskIds;
+        const { workDuration } = get();
+        set({
+          selectedTaskId: first,
+          taskQueue: rest,
+          phase: 'work',
+          status: 'running',
+          secondsRemaining: workDuration * 60,
+          cycleStartedAt: Date.now(),
+        });
+        ensurePomodoroInterval();
       },
 
       reconcileRunningTimer: () => {


### PR DESCRIPTION
Closes #11

## Summary

- ⏱️ Focus session ending **automatically starts the break** — no tap required
- ⚙️ **Timer settings** modal (gear icon in header) to customise focus/break duration (1–60 min)
- 📋 **Bulk task queue** — tap tasks to queue them in order, press Start queue to run hands-free; timer advances through all tasks automatically
- Break ending with an active queue **auto-starts the next task's focus session**

## Test plan

- [ ] Complete a 25-min focus session — break starts automatically
- [ ] Break ends with no queue — timer goes idle
- [ ] Tap gear icon → TimerSettings modal opens; change durations, save — timer resets to new values
- [ ] In "Bulk tasks", tap tasks to queue them (numbered badges appear); press Start queue — timer starts on first task
- [ ] After first focus+break cycle, second task starts automatically
- [ ] `pnpm jest --coverage` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)