### PR TITLE
🐛 fix(task-modal): improve contrast and default due date to today

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.superpowers/
 node_modules/
 .expo/
 dist/

--- a/docs/superpowers/plans/2026-04-08-task-modal-contrast-default-date.md
+++ b/docs/superpowers/plans/2026-04-08-task-modal-contrast-default-date.md
@@ -1,0 +1,386 @@
+# Task Modal Contrast & Default Due Date — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix failing WCAG contrast on section labels, fix dark-mode visual inconsistency on inactive priority buttons, and default the due date field to today when the modal opens.
+
+**Architecture:** All changes are confined to `AddTaskModal.tsx`. Labels switch from hardcoded `text-gray-600` to `style={{ color: theme.textMuted }}`. Inactive priority buttons gain a `PRIORITY_BG_DARK` map applied when `theme.isDark` is true. Due date state initialises with `todayAtEod()` instead of `null`, with matching `resetForm()` update.
+
+**Tech Stack:** React Native, NativeWind (Tailwind), `@testing-library/react-native`, Jest
+
+**Spec:** `docs/superpowers/specs/2026-04-08-task-modal-contrast-default-date-design.md`
+
+---
+
+## Task 1: Update "Clear button" test for new default-today behaviour
+
+The existing test expects no Clear button on open. After Task 3, `dueDate` starts non-null, so Clear appears immediately. Update the test now so it fails (red) before we implement.
+
+**Files:**
+
+- Modify: `src/components/tasks/__tests__/AddTaskModal.test.tsx`
+
+- [ ] **Step 1: Replace the "shows Clear button" test body**
+
+In `AddTaskModal.test.tsx`, find the test `'shows Clear button when due date is set and clears it'` (currently around line 253) and replace its body:
+
+```ts
+it('shows Clear button when due date is set and clears it', () => {
+  const { getByTestId, getByText, queryByText } = render(
+    <AddTaskModal visible onClose={jest.fn()} />
+  );
+
+  // Clear is visible immediately because due date defaults to today
+  expect(getByText('Clear')).toBeTruthy();
+
+  // Press Clear — due date becomes null, Clear disappears
+  fireEvent.press(getByText('Clear'));
+  expect(queryByText('Clear')).toBeNull();
+
+  // Open picker and set a date via the mock — Clear reappears
+  fireEvent.press(getByTestId('due-date-open'));
+  fireEvent.press(getByTestId('mock-datetime-picker'));
+  fireEvent.press(getByTestId('due-date-picker-modal-done'));
+  expect(getByText('Clear')).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Update the web test comment**
+
+Find `'calls parseDateToEndOfDay via handleAdd with a due date input on web'` and replace it:
+
+```ts
+it('calls parseDateToEndOfDay via handleAdd with a due date input on web', () => {
+  const onClose = jest.fn();
+  const { getByTestId } = render(<AddTaskModal visible onClose={onClose} />);
+
+  fireEvent.changeText(getByTestId('task-title-input'), 'Web task');
+
+  // dueDateInput defaults to today's ISO date, so parseDateToEndOfDay
+  // returns today at 23:59 and addTask receives a valid dueDate timestamp.
+  fireEvent.press(getByTestId('add-task-submit'));
+
+  expect(mockAddTask).toHaveBeenCalledWith(expect.objectContaining({ title: 'Web task' }));
+  expect(onClose).toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 3: Run the suite to confirm the updated test fails (red)**
+
+```bash
+pnpm jest AddTaskModal.test --no-coverage
+```
+
+Expected: `'shows Clear button when due date is set and clears it'` FAILS with `Unable to find an element with text: 'Clear'`. All other tests pass.
+
+---
+
+## Task 2: Add label colour assertions to theme test
+
+Write failing assertions for section labels using `theme.textMuted`.
+
+**Files:**
+
+- Modify: `src/components/tasks/__tests__/AddTaskModal.theme.test.tsx`
+
+- [ ] **Step 1: Add a new test for label colours**
+
+Append inside the `'AddTaskModal dark theme input'` describe block, after the existing test:
+
+```ts
+it('uses theme.textMuted colour for all section labels', () => {
+  const { getByText } = render(<AddTaskModal visible onClose={jest.fn()} />);
+
+  for (const label of [
+    'Priority',
+    'Recurring task',
+    'Start focus immediately',
+    'Due date',
+    'Reminder',
+  ]) {
+    const el = getByText(label);
+    expect(el.props.style).toEqual(expect.objectContaining({ color: '#cbd5e1' }));
+  }
+});
+```
+
+- [ ] **Step 2: Add a new test for inactive priority button text colour**
+
+Append after the label colour test:
+
+```ts
+it('uses theme.textMuted colour for inactive priority button text in dark mode', () => {
+  const { getAllByText } = render(<AddTaskModal visible onClose={jest.fn()} />);
+
+  // Default priority is 'medium' → High and Low are inactive
+  const highText = getAllByText('High')[0];
+  expect(highText.props.style).toEqual(expect.objectContaining({ color: '#cbd5e1' }));
+
+  const lowText = getAllByText('Low')[0];
+  expect(lowText.props.style).toEqual(expect.objectContaining({ color: '#cbd5e1' }));
+
+  // Medium is active → no textMuted colour applied
+  const medText = getAllByText('Medium')[0];
+  expect(medText.props.style).not.toEqual(expect.objectContaining({ color: '#cbd5e1' }));
+});
+```
+
+- [ ] **Step 3: Run the theme test to confirm both new tests fail (red)**
+
+```bash
+pnpm jest AddTaskModal.theme --no-coverage
+```
+
+Expected: two new tests FAIL. Existing test passes.
+
+---
+
+## Task 3: Default due date to today
+
+Implement the due date initialisation change — this makes Task 1's updated test go green.
+
+**Files:**
+
+- Modify: `src/components/tasks/AddTaskModal.tsx`
+
+- [ ] **Step 1: Add helper functions just above the `AddTaskModal` function**
+
+Insert these two lines immediately before `export function AddTaskModal`:
+
+```ts
+const todayAtEod = () => { const d = new Date(); d.setHours(23, 59, 0, 0); return d; };
+const todayISO   = () => new Date().toISOString().slice(0, 10);
+```
+
+- [ ] **Step 2: Update `dueDate` initial state**
+
+Find:
+
+```ts
+const [dueDate, setDueDate] = useState<Date | null>(null);
+```
+
+Replace with:
+
+```ts
+const [dueDate, setDueDate] = useState<Date | null>(todayAtEod);
+```
+
+- [ ] **Step 3: Update `dueDateInput` initial state**
+
+Find:
+
+```ts
+const [dueDateInput, setDueDateInput] = useState(''); // web fallback
+```
+
+Replace with:
+
+```ts
+const [dueDateInput, setDueDateInput] = useState(todayISO); // web fallback
+```
+
+- [ ] **Step 4: Update `resetForm` to reset to today**
+
+Find in `resetForm()`:
+
+```ts
+setDueDate(null);
+setShowDueDatePicker(false);
+setDueDateInput('');
+```
+
+Replace with:
+
+```ts
+setDueDate(todayAtEod());
+setShowDueDatePicker(false);
+setDueDateInput(todayISO());
+```
+
+- [ ] **Step 5: Run both test files — Task 1 should now be green**
+
+```bash
+pnpm jest AddTaskModal --no-coverage
+```
+
+Expected: `AddTaskModal.test` fully passes. `AddTaskModal.theme` still has 2 failing tests (fixed in Tasks 4–5).
+
+---
+
+## Task 4: Fix section label colours
+
+Replace hardcoded `text-gray-600` with `style={{ color: theme.textMuted }}` on all 6 section labels.
+
+**Files:**
+
+- Modify: `src/components/tasks/AddTaskModal.tsx`
+
+- [ ] **Step 1: Fix "Priority" label**
+
+Find:
+
+```tsx
+<Text className="text-sm font-medium text-gray-600 mb-2">Priority</Text>
+```
+
+Replace with:
+
+```tsx
+<Text className="text-sm font-medium mb-2" style={{ color: theme.textMuted }}>Priority</Text>
+```
+
+- [ ] **Step 2: Fix "Recurring task" label**
+
+Find:
+
+```tsx
+<Text className="text-sm font-medium text-gray-600">Recurring task</Text>
+```
+
+Replace with:
+
+```tsx
+<Text className="text-sm font-medium" style={{ color: theme.textMuted }}>Recurring task</Text>
+```
+
+- [ ] **Step 3: Fix "Start focus immediately" label**
+
+Find:
+
+```tsx
+<Text className="text-sm font-medium text-gray-600">Start focus immediately</Text>
+```
+
+Replace with:
+
+```tsx
+<Text className="text-sm font-medium" style={{ color: theme.textMuted }}>Start focus immediately</Text>
+```
+
+- [ ] **Step 4: Fix "Due date" label**
+
+Find:
+
+```tsx
+<Text className="text-sm font-medium text-gray-600">Due date</Text>
+```
+
+Replace with:
+
+```tsx
+<Text className="text-sm font-medium" style={{ color: theme.textMuted }}>Due date</Text>
+```
+
+- [ ] **Step 5: Fix "Reminder" label**
+
+Find:
+
+```tsx
+<Text className="text-sm font-medium text-gray-600">Reminder</Text>
+```
+
+Replace with:
+
+```tsx
+<Text className="text-sm font-medium" style={{ color: theme.textMuted }}>Reminder</Text>
+```
+
+- [ ] **Step 6: Fix "Category" label**
+
+Find:
+
+```tsx
+<Text className="text-sm font-medium text-gray-600 mb-2">Category</Text>
+```
+
+Replace with:
+
+```tsx
+<Text className="text-sm font-medium mb-2" style={{ color: theme.textMuted }}>Category</Text>
+```
+
+- [ ] **Step 7: Run theme test — label colour test should now pass**
+
+```bash
+pnpm jest AddTaskModal.theme --no-coverage
+```
+
+Expected: `'uses theme.textMuted colour for all section labels'` passes. `'uses theme.textMuted colour for inactive priority button text'` still fails.
+
+---
+
+## Task 5: Fix inactive priority button backgrounds and text
+
+Add `PRIORITY_BG_DARK` and apply it conditionally on inactive buttons.
+
+**Files:**
+
+- Modify: `src/components/tasks/AddTaskModal.tsx`
+
+- [ ] **Step 1: Add `PRIORITY_BG_DARK` constant after `PRIORITY_ACTIVE`**
+
+After the existing `PRIORITY_ACTIVE` constant (around line 36), insert:
+
+```ts
+const PRIORITY_BG_DARK: Record<Priority, { backgroundColor: string; borderColor: string }> = {
+  high:   { backgroundColor: 'rgba(239,68,68,0.15)',   borderColor: 'rgba(239,68,68,0.5)'  },
+  medium: { backgroundColor: 'rgba(251,191,36,0.15)',  borderColor: 'rgba(251,191,36,0.5)' },
+  low:    { backgroundColor: 'rgba(52,211,153,0.15)',  borderColor: 'rgba(52,211,153,0.5)' },
+};
+```
+
+- [ ] **Step 2: Update the priority button render**
+
+Find:
+
+```tsx
+<TouchableOpacity
+  key={p}
+  onPress={() => setPriority(p)}
+  className={`flex-1 py-2 rounded-lg border ${priority === p ? PRIORITY_ACTIVE[p] : PRIORITY_COLORS[p]}`}>
+  <Text
+    className={`text-center text-sm font-medium ${priority === p ? 'text-white' : 'text-gray-700'}`}>
+    {PRIORITY_LABELS[p]}
+  </Text>
+</TouchableOpacity>
+```
+
+Replace with:
+
+```tsx
+<TouchableOpacity
+  key={p}
+  onPress={() => setPriority(p)}
+  className={`flex-1 py-2 rounded-lg border ${
+    priority === p ? PRIORITY_ACTIVE[p] : theme.isDark ? '' : PRIORITY_COLORS[p]
+  }`}
+  style={priority !== p && theme.isDark ? PRIORITY_BG_DARK[p] : undefined}>
+  <Text
+    className={`text-center text-sm font-medium ${priority === p ? 'text-white' : ''}`}
+    style={priority !== p ? { color: theme.textMuted } : undefined}>
+    {PRIORITY_LABELS[p]}
+  </Text>
+</TouchableOpacity>
+```
+
+- [ ] **Step 3: Run the full suite — all tests should pass**
+
+```bash
+pnpm jest --coverage
+```
+
+Expected: all tests pass, coverage unchanged or improved.
+
+---
+
+## Task 6: Commit
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+git add src/components/tasks/AddTaskModal.tsx \
+        src/components/tasks/__tests__/AddTaskModal.test.tsx \
+        src/components/tasks/__tests__/AddTaskModal.theme.test.tsx
+git commit -m "fix(task-modal): improve contrast and default due date to today"
+```

--- a/docs/superpowers/specs/2026-04-08-task-modal-contrast-default-date-design.md
+++ b/docs/superpowers/specs/2026-04-08-task-modal-contrast-default-date-design.md
@@ -1,0 +1,96 @@
+# Task Modal — Contrast & Default Due Date
+
+**Issue:** codex-foundation/slow-to-pro#16  
+**Date:** 2026-04-08  
+**Status:** Approved
+
+## Problem
+
+Two independent issues in `AddTaskModal.tsx`:
+
+1. **Contrast failure:** Six section labels (Priority, Recurring task, Start focus immediately, Due date, Reminder, Category) use hardcoded `text-gray-600` (`#4b5563`), which yields a 2.9:1 contrast ratio on the dark modal background (`#111827`). WCAG AA requires 4.5:1 for normal text.
+
+2. **Visual inconsistency:** Inactive priority buttons use light Tailwind backgrounds (`bg-red-50`, `bg-amber-50`, `bg-green-50`) that appear as bright islands on the dark surface. This is not a contrast failure (text-on-button passes), but it breaks visual coherence in dark mode.
+
+3. **Due date UX:** The due date field opens empty (`null` / `''`), requiring an extra tap for the common case of scheduling to today.
+
+## Scope
+
+All changes are confined to `AddTaskModal.tsx` and its test files. No other components or the theme system are modified.
+
+## Design
+
+### 1. Section Labels
+
+Replace hardcoded `text-gray-600` with `style={{ color: theme.textMuted }}` on all six label `<Text>` elements. Remove the Tailwind color class from `className`.
+
+- Dark mode: `#cbd5e1` on `#111827` → **12:1** (passes WCAG AAA)
+- Light mode: `#334155` on `#ffffff` → **10.3:1** (passes WCAG AAA)
+
+### 2. Inactive Priority Button Backgrounds
+
+Add a `PRIORITY_BG_DARK` constant mapping each priority to an inline style object with semi-transparent `rgba` background and border colors:
+
+```ts
+const PRIORITY_BG_DARK: Record<Priority, object> = {
+  high:   { backgroundColor: 'rgba(239,68,68,0.15)',   borderColor: 'rgba(239,68,68,0.5)'  },
+  medium: { backgroundColor: 'rgba(251,191,36,0.15)',  borderColor: 'rgba(251,191,36,0.5)' },
+  low:    { backgroundColor: 'rgba(52,211,153,0.15)',  borderColor: 'rgba(52,211,153,0.5)' },
+};
+```
+
+Apply conditionally on inactive buttons:
+
+- `className`: keep `PRIORITY_COLORS[p]` in light mode, drop in dark (empty string)
+- `style`: apply `PRIORITY_BG_DARK[p]` in dark mode, `undefined` in light
+- Inactive text: use `style={{ color: theme.textMuted }}` instead of hardcoded `text-gray-700`
+
+Active state (`PRIORITY_ACTIVE`) is unchanged.
+
+### 3. Due Date Defaults to Today
+
+Add two lazy-initializer helpers at the top of the component:
+
+```ts
+const todayAtEod = () => { const d = new Date(); d.setHours(23, 59, 0, 0); return d; };
+const todayISO   = () => new Date().toISOString().slice(0, 10);
+```
+
+Change initial state:
+
+```ts
+// Before
+const [dueDate, setDueDate]       = useState<Date | null>(null);
+const [dueDateInput, setDueDateInput] = useState('');
+
+// After
+const [dueDate, setDueDate]       = useState<Date>(todayAtEod);
+const [dueDateInput, setDueDateInput] = useState(todayISO);
+```
+
+Update `resetForm()` to reset back to today (not null):
+
+```ts
+setDueDate(todayAtEod());
+setDueDateInput(todayISO());
+```
+
+The "Clear" button remains and resets to `null` / `''` (no due date), which is still useful. Because `dueDate` is non-null on open, the "Clear" button will be visible immediately when the modal opens. Tapping it sets due date to null (no due date). `hasDueDateValue` remains accurate — it evaluates to `true` on open (today is set), and `false` after clearing.
+
+### Error Handling
+
+No new error paths. The `todayAtEod()` helper always returns a valid `Date`. Existing `parseDateToEndOfDay` and `buildTaskPayload` logic is unchanged.
+
+## Testing
+
+- `AddTaskModal.test.tsx`: Update any assertions that expect the due date field to be empty on open — it now shows today's date.
+- `AddTaskModal.theme.test.tsx`: Update label color assertions from `text-gray-600` / `#4b5563` to `theme.textMuted`.
+- Run `pnpm jest --coverage` to confirm full suite passes.
+
+## Files Changed
+
+| File | Change |
+| --- | --- |
+| `src/components/tasks/AddTaskModal.tsx` | Labels, priority buttons, due date default |
+| `src/components/tasks/__tests__/AddTaskModal.test.tsx` | Update due date open-state assertions |
+| `src/components/tasks/__tests__/AddTaskModal.theme.test.tsx` | Update label color assertions |

--- a/src/components/tasks/AddTaskModal.tsx
+++ b/src/components/tasks/AddTaskModal.tsx
@@ -34,6 +34,11 @@ const PRIORITY_ACTIVE: Record<Priority, string> = {
   medium: 'bg-amber-400 border-amber-400',
   low: 'bg-green-500 border-green-500',
 };
+const PRIORITY_BG_DARK: Record<Priority, { backgroundColor: string; borderColor: string }> = {
+  high: { backgroundColor: 'rgba(239,68,68,0.15)', borderColor: 'rgba(239,68,68,0.5)' },
+  medium: { backgroundColor: 'rgba(251,191,36,0.15)', borderColor: 'rgba(251,191,36,0.5)' },
+  low: { backgroundColor: 'rgba(52,211,153,0.15)', borderColor: 'rgba(52,211,153,0.5)' },
+};
 
 interface Props {
   visible: boolean;
@@ -102,6 +107,13 @@ function PickerSheet({ visible, title, testID, onClose, onConfirm, children }: P
   );
 }
 
+const todayAtEod = () => {
+  const d = new Date();
+  d.setHours(23, 59, 0, 0);
+  return d;
+};
+const todayISO = () => new Date().toISOString().slice(0, 10);
+
 export function AddTaskModal({ visible, onClose }: Props) {
   const theme = useAppTheme();
   const router = useRouter();
@@ -116,9 +128,9 @@ export function AddTaskModal({ visible, onClose }: Props) {
   const [recurring, setRecurring] = useState(false);
   const [days, setDays] = useState<number[]>([]);
   const [startFocusNow, setStartFocusNow] = useState(false);
-  const [dueDate, setDueDate] = useState<Date | null>(null);
+  const [dueDate, setDueDate] = useState<Date | null>(todayAtEod);
   const [showDueDatePicker, setShowDueDatePicker] = useState(false);
-  const [dueDateInput, setDueDateInput] = useState(''); // web fallback
+  const [dueDateInput, setDueDateInput] = useState(todayISO); // web fallback
   const [reminderEnabled, setReminderEnabled] = useState(false);
   const [reminderDateTime, setReminderDateTime] = useState<Date | null>(null);
   const [showReminderDatePicker, setShowReminderDatePicker] = useState(false);
@@ -278,9 +290,9 @@ export function AddTaskModal({ visible, onClose }: Props) {
     setRecurring(false);
     setDays([]);
     setStartFocusNow(false);
-    setDueDate(null);
+    setDueDate(todayAtEod());
     setShowDueDatePicker(false);
-    setDueDateInput('');
+    setDueDateInput(todayISO());
     setReminderEnabled(false);
     setReminderDateTime(null);
     setShowReminderDatePicker(false);
@@ -342,15 +354,21 @@ export function AddTaskModal({ visible, onClose }: Props) {
           onSubmitEditing={Keyboard.dismiss}
         />
 
-        <Text className="text-sm font-medium text-gray-600 mb-2">Priority</Text>
+        <Text className="text-sm font-medium mb-2" style={{ color: theme.textMuted }}>
+          Priority
+        </Text>
         <View className="flex-row gap-2 mb-4">
           {PRIORITIES.map((p) => (
             <TouchableOpacity
               key={p}
               onPress={() => setPriority(p)}
-              className={`flex-1 py-2 rounded-lg border ${priority === p ? PRIORITY_ACTIVE[p] : PRIORITY_COLORS[p]}`}>
+              className={`flex-1 py-2 rounded-lg border ${
+                priority === p ? PRIORITY_ACTIVE[p] : theme.isDark ? '' : PRIORITY_COLORS[p]
+              }`}
+              style={priority !== p && theme.isDark ? PRIORITY_BG_DARK[p] : undefined}>
               <Text
-                className={`text-center text-sm font-medium ${priority === p ? 'text-white' : 'text-gray-700'}`}>
+                className={`text-center text-sm font-medium ${priority === p ? 'text-white' : ''}`}
+                style={priority !== p ? { color: theme.textMuted } : undefined}>
                 {PRIORITY_LABELS[p]}
               </Text>
             </TouchableOpacity>
@@ -359,7 +377,9 @@ export function AddTaskModal({ visible, onClose }: Props) {
 
         <View className="flex-row items-center justify-between mb-3">
           <View className="flex-row items-center gap-1">
-            <Text className="text-sm font-medium text-gray-600">Recurring task</Text>
+            <Text className="text-sm font-medium" style={{ color: theme.textMuted }}>
+              Recurring task
+            </Text>
             {!isPro && <Ionicons name="lock-closed-outline" size={12} color={theme.textSubtle} />}
           </View>
           <Switch
@@ -377,7 +397,9 @@ export function AddTaskModal({ visible, onClose }: Props) {
         </View>
 
         <View className="flex-row items-center justify-between mb-4">
-          <Text className="text-sm font-medium text-gray-600">Start focus immediately</Text>
+          <Text className="text-sm font-medium" style={{ color: theme.textMuted }}>
+            Start focus immediately
+          </Text>
           <Switch
             testID="start-focus-switch"
             value={startFocusNow}
@@ -387,7 +409,9 @@ export function AddTaskModal({ visible, onClose }: Props) {
         </View>
 
         <View className="flex-row items-center justify-between mb-2">
-          <Text className="text-sm font-medium text-gray-600">Due date</Text>
+          <Text className="text-sm font-medium" style={{ color: theme.textMuted }}>
+            Due date
+          </Text>
           {hasDueDateValue ? (
             <TouchableOpacity onPress={clearDueDate}>
               <Text className="text-xs font-medium text-gray-400">Clear</Text>
@@ -436,7 +460,9 @@ export function AddTaskModal({ visible, onClose }: Props) {
 
         <View className="flex-row items-center justify-between mb-3">
           <View className="flex-row items-center gap-1">
-            <Text className="text-sm font-medium text-gray-600">Reminder</Text>
+            <Text className="text-sm font-medium" style={{ color: theme.textMuted }}>
+              Reminder
+            </Text>
             {!isPro && <Ionicons name="lock-closed-outline" size={12} color={theme.textSubtle} />}
           </View>
           <View className="flex-row items-center gap-3">
@@ -562,7 +588,9 @@ export function AddTaskModal({ visible, onClose }: Props) {
 
         {categories.length > 0 && (
           <>
-            <Text className="text-sm font-medium text-gray-600 mb-2">Category</Text>
+            <Text className="text-sm font-medium mb-2" style={{ color: theme.textMuted }}>
+              Category
+            </Text>
             <ScrollView
               horizontal
               showsHorizontalScrollIndicator={false}

--- a/src/components/tasks/__tests__/AddTaskModal.test.tsx
+++ b/src/components/tasks/__tests__/AddTaskModal.test.tsx
@@ -255,18 +255,18 @@ describe('AddTaskModal date/reminder picker modals', () => {
       <AddTaskModal visible onClose={jest.fn()} />
     );
 
-    // No Clear button initially
+    // Clear is visible immediately because due date defaults to today
+    expect(getByText('Clear')).toBeTruthy();
+
+    // Press Clear — due date becomes null, Clear disappears
+    fireEvent.press(getByText('Clear'));
     expect(queryByText('Clear')).toBeNull();
 
-    // Open due date picker and set a date via mock picker
+    // Open picker and set a date via the mock — Clear reappears
     fireEvent.press(getByTestId('due-date-open'));
     fireEvent.press(getByTestId('mock-datetime-picker'));
     fireEvent.press(getByTestId('due-date-picker-modal-done'));
-
-    // Now Clear button should appear — press it
-    fireEvent.press(getByText('Clear'));
-    // After clearing, Clear disappears and due-date-open still present
-    expect(queryByText('Clear')).toBeNull();
+    expect(getByText('Clear')).toBeTruthy();
   });
 
   it('shows Clear button when reminder is set and clears it', () => {
@@ -285,8 +285,8 @@ describe('AddTaskModal date/reminder picker modals', () => {
     expect(clearBtns.length).toBeGreaterThan(0);
     fireEvent.press(clearBtns[clearBtns.length - 1]);
 
-    // After clearing, reminder is disabled
-    expect(queryAllByText('Clear')).toHaveLength(0);
+    // After clearing, reminder is disabled, but one Clear button remains (due-date Clear, which defaults to today)
+    expect(queryAllByText('Clear')).toHaveLength(1);
   });
 
   it('opens reminder time picker when reminderDateTime already set', () => {
@@ -363,7 +363,8 @@ describe('AddTaskModal web platform paths', () => {
 
     fireEvent.changeText(getByTestId('task-title-input'), 'Web task');
 
-    // With empty dueDateInput, parseDateToEndOfDay returns undefined (no due date)
+    // dueDateInput defaults to today's ISO date, so parseDateToEndOfDay
+    // returns today at 23:59 and addTask receives a valid dueDate timestamp.
     fireEvent.press(getByTestId('add-task-submit'));
 
     expect(mockAddTask).toHaveBeenCalledWith(expect.objectContaining({ title: 'Web task' }));

--- a/src/components/tasks/__tests__/AddTaskModal.theme.test.tsx
+++ b/src/components/tasks/__tests__/AddTaskModal.theme.test.tsx
@@ -49,12 +49,12 @@ jest.mock('@/hooks/useAppTheme', () => ({
   }),
 }));
 
-const mockAddTask = jest.fn(() => 'task-id');
+const _mockAddTask = jest.fn(() => 'task-id');
 const mockStartWorkForTask = jest.fn();
+const mockUseTaskStore = jest.fn();
 
 jest.mock('@/stores/taskStore', () => ({
-  useTaskStore: (selector: (s: { addTask: typeof mockAddTask; categories: [] }) => unknown) =>
-    selector({ addTask: mockAddTask, categories: [] }),
+  useTaskStore: (selector: Parameters<typeof mockUseTaskStore>[0]) => mockUseTaskStore(selector),
 }));
 
 jest.mock('@/stores/pomodoroStore', () => ({
@@ -68,7 +68,16 @@ jest.mock('@/stores/entitlementStore', () => ({
 
 import { AddTaskModal } from '../AddTaskModal';
 
+const DARK_TEXT_MUTED = '#cbd5e1';
+
 describe('AddTaskModal dark theme input', () => {
+  beforeEach(() => {
+    mockUseTaskStore.mockImplementation(
+      (selector: (s: { addTask: jest.Mock; categories: [] }) => unknown) =>
+        selector({ addTask: jest.fn(() => 'id'), categories: [] })
+    );
+  });
+
   it('uses theme colors for task title input text and placeholder', () => {
     mockDateTimePicker.mockClear();
     const { getByTestId } = render(<AddTaskModal visible onClose={jest.fn()} />);
@@ -118,5 +127,54 @@ describe('AddTaskModal dark theme input', () => {
     };
     expect(lastCallArgs?.themeVariant).toBe('dark');
     expect(lastCallArgs?.textColor).toBe('#f8fafc');
+  });
+
+  it('uses theme.textMuted colour for all section labels', () => {
+    const { getByText } = render(<AddTaskModal visible onClose={jest.fn()} />);
+
+    for (const label of [
+      'Priority',
+      'Recurring task',
+      'Start focus immediately',
+      'Due date',
+      'Reminder',
+    ]) {
+      const el = getByText(label);
+      expect(el.props.style).toEqual(expect.objectContaining({ color: DARK_TEXT_MUTED }));
+    }
+  });
+
+  it('uses theme.textMuted colour for inactive priority button text in dark mode', () => {
+    const { getAllByText } = render(<AddTaskModal visible onClose={jest.fn()} />);
+
+    // Default priority is 'medium' → High and Low are inactive
+    const highText = getAllByText('High')[0];
+    expect(highText.props.style).toEqual(expect.objectContaining({ color: DARK_TEXT_MUTED }));
+
+    const lowText = getAllByText('Low')[0];
+    expect(lowText.props.style).toEqual(expect.objectContaining({ color: DARK_TEXT_MUTED }));
+
+    // Medium is active → no textMuted colour applied
+    const medText = getAllByText('Medium')[0];
+    expect(medText.props.style).not.toEqual(expect.objectContaining({ color: DARK_TEXT_MUTED }));
+  });
+
+  it('uses theme.textMuted colour for Category label when categories exist', () => {
+    mockUseTaskStore.mockImplementation(
+      (
+        selector: (s: {
+          addTask: jest.Mock;
+          categories: { id: string; name: string; color: string }[];
+        }) => unknown
+      ) =>
+        selector({
+          addTask: jest.fn(() => 'id'),
+          categories: [{ id: 'c1', name: 'Work', color: '#6366f1' }],
+        })
+    );
+
+    const { getByText } = render(<AddTaskModal visible onClose={jest.fn()} />);
+    const el = getByText('Category');
+    expect(el.props.style).toEqual(expect.objectContaining({ color: DARK_TEXT_MUTED }));
   });
 });


### PR DESCRIPTION
Closes #16

## Summary

- Replace hardcoded `text-gray-600` labels with `theme.textMuted` on all 6 section labels (Priority, Recurring task, Start focus immediately, Due date, Reminder, Category) — fixes 2.9:1 contrast ratio to 12:1, passing WCAG AAA
- Fix inactive priority button backgrounds in dark mode: replace light Tailwind tints (`bg-red-50` etc.) with dark `rgba` tints via `PRIORITY_BG_DARK` map
- Default due date to today (end of day) on both native and web; `resetForm()` resets back to today rather than null

## Test Plan

- [ ] Open the New Task modal in dark mode — section labels are clearly readable
- [ ] Inactive priority buttons show subtle tinted backgrounds (not bright light islands)
- [ ] Due date field shows today's date on open
- [ ] Pressing "Clear" on due date removes it; opening picker again restores a date
- [ ] "+ Another" resets due date back to today
- [ ] All 730 tests pass: `pnpm jest --coverage`