### PR TITLE
fix: reset focus and break timers to defaults on new space creation

### DIFF
--- a/src/services/spaceSync.ts
+++ b/src/services/spaceSync.ts
@@ -158,6 +158,9 @@ export async function createSpace(name: string): Promise<{ space: Space | null; 
 
   const store = useSpaceStore.getState();
   store.setSpaces([...store.spaces, space]);
+
+  usePomodoroStore.getState().updateDurations(25, 5);
+
   return { space };
 }
 


### PR DESCRIPTION
Closes #18\n\nWhen a new space is created, updateDurations(25, 5) is called, resetting focus timer to 25 min and break timer to 5 min.